### PR TITLE
Disable Redisgraph deployment in upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ COPY --from=builder /workspace/manager .
 ENV OPERATOR=/usr/local/bin/search-operator \
     USER_UID=1001 \
     USER_NAME=search-operator \
-    DEPLOY_REDISGRAPH="false"
+    DEPLOY_REDISGRAPH="true"
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ COPY --from=builder /workspace/manager .
 ENV OPERATOR=/usr/local/bin/search-operator \
     USER_UID=1001 \
     USER_NAME=search-operator \
-    DEPLOY_REDISGRAPH="true"
+    DEPLOY_REDISGRAPH="true" 
+    # TODO: Default to false once other components are ready
+
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ WORKDIR /
 COPY --from=builder /workspace/manager .
 ENV OPERATOR=/usr/local/bin/search-operator \
     USER_UID=1001 \
-    USER_NAME=search-operator
+    USER_NAME=search-operator \
+    DEPLOY_REDISGRAPH="false"
 
 ENTRYPOINT ["/manager"]

--- a/cicd-scripts/run-e2e-tests.sh
+++ b/cicd-scripts/run-e2e-tests.sh
@@ -132,6 +132,7 @@ echo "=====Initial setup for tests====="
     echo "=====Deploying search-operator====="
 	$sed_command "s~{{ OPERATOR_IMAGE }}~$IMAGE_NAME~g" ./test/operator-deployment.yaml
 	echo -n "Applying search operator deployment: " && kubectl apply -f ./test/operator-deployment.yaml
+	echo -n "Set DEPLOY_REDISGRAPH variable: " && kubectl set env deploy search-operator DEPLOY_REDISGRAPH="true"
 	# # change the image name back to OPERATOR_IMAGE in operator deployment for next run
 	sed -i '-e' "s~$IMAGE_NAME~{{ OPERATOR_IMAGE }}~g" ./test/operator-deployment.yaml
 }

--- a/controllers/searchoperator_controller.go
+++ b/controllers/searchoperator_controller.go
@@ -68,7 +68,7 @@ var (
 	storageClass         = ""
 	storageSize          = "10Gi"
 	namespace            = os.Getenv("WATCH_NAMESPACE")
-	setupPod, _          = strconv.ParseBool(os.Getenv("USE_EXISTING_REDISGRAPH"))
+	setupPod, _          = strconv.ParseBool(os.Getenv("DEPLOY_REDISGRAPH"))
 )
 var startingSpec searchv1alpha1.SearchCustomizationSpec
 
@@ -148,7 +148,7 @@ func (r *SearchOperatorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 
 	// Setup RedisGraph Deployment
 	r.Log.Info(fmt.Sprintf("Config in  Use Persistence/AllowDegrade %t/%t", persistence, allowdegrade))
-	if setupPod {
+	if !setupPod {
 		r.Log.Info("Not deploying redisgraph. Using custom/existing deployment of Redisgraph pod")
 		return ctrl.Result{}, nil
 	}

--- a/controllers/searchoperator_controller.go
+++ b/controllers/searchoperator_controller.go
@@ -60,16 +60,16 @@ const (
 )
 
 var (
-	pvcName              = "search-redisgraph-pvc-0"
-	waitSecondsForPodChk = 180 //Wait for 3 minutes
-	log                  = logf.Log.WithName("searchoperator")
-	persistence          = true
-	allowdegrade         = true
-	storageClass         = ""
-	storageSize          = "10Gi"
-	namespace            = os.Getenv("WATCH_NAMESPACE")
-	deployRedisgraphPod  = os.Getenv("DEPLOY_REDISGRAPH")
-	deploy, deployVarErr = strconv.ParseBool(deployRedisgraphPod)
+	pvcName                               = "search-redisgraph-pvc-0"
+	waitSecondsForPodChk                  = 180 //Wait for 3 minutes
+	log                                   = logf.Log.WithName("searchoperator")
+	persistence                           = true
+	allowdegrade                          = true
+	storageClass                          = ""
+	storageSize                           = "10Gi"
+	namespace                             = os.Getenv("WATCH_NAMESPACE")
+	deployRedisgraphPod, deployVarPresent = os.LookupEnv("DEPLOY_REDISGRAPH")
+	deploy, deployVarErr                  = strconv.ParseBool(deployRedisgraphPod)
 )
 var startingSpec searchv1alpha1.SearchCustomizationSpec
 
@@ -150,7 +150,7 @@ func (r *SearchOperatorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	// Setup RedisGraph Deployment
 	r.Log.Info(fmt.Sprintf("Config in  Use Persistence/AllowDegrade %t/%t", persistence, allowdegrade))
 	//if deploy env variable is false, don't deploy Redisgraph pod
-	if deployRedisgraphPod != "" && deployVarErr == nil && !deploy {
+	if deployVarPresent && deployVarErr == nil && !deploy {
 		err := deleteRedisStatefulSet(r.Client) //if redisgraph pod is already deployed, delete it.
 		if err != nil {
 			return ctrl.Result{}, err

--- a/controllers/searchoperator_controller.go
+++ b/controllers/searchoperator_controller.go
@@ -60,14 +60,15 @@ const (
 )
 
 var (
-	pvcName                               = "search-redisgraph-pvc-0"
-	waitSecondsForPodChk                  = 180 //Wait for 3 minutes
-	log                                   = logf.Log.WithName("searchoperator")
-	persistence                           = true
-	allowdegrade                          = true
-	storageClass                          = ""
-	storageSize                           = "10Gi"
-	namespace                             = os.Getenv("WATCH_NAMESPACE")
+	pvcName              = "search-redisgraph-pvc-0"
+	waitSecondsForPodChk = 180 //Wait for 3 minutes
+	log                  = logf.Log.WithName("searchoperator")
+	persistence          = true
+	allowdegrade         = true
+	storageClass         = ""
+	storageSize          = "10Gi"
+	namespace            = os.Getenv("WATCH_NAMESPACE")
+	//Keeping these here as the pod will restart everytime when ENV is updated and we will read the updated values
 	deployRedisgraphPod, deployVarPresent = os.LookupEnv("DEPLOY_REDISGRAPH")
 	deploy, deployVarErr                  = strconv.ParseBool(deployRedisgraphPod)
 )

--- a/controllers/searchoperator_controller.go
+++ b/controllers/searchoperator_controller.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"os"
 	"reflect"
+	"strconv"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -67,6 +68,7 @@ var (
 	storageClass         = ""
 	storageSize          = "10Gi"
 	namespace            = os.Getenv("WATCH_NAMESPACE")
+	setupPod, _          = strconv.ParseBool(os.Getenv("DOWNSTREAM"))
 )
 var startingSpec searchv1alpha1.SearchCustomizationSpec
 
@@ -146,83 +148,84 @@ func (r *SearchOperatorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 
 	// Setup RedisGraph Deployment
 	r.Log.Info(fmt.Sprintf("Config in  Use Persistence/AllowDegrade %t/%t", persistence, allowdegrade))
-	if persistence {
-		//If running PVC deployment nothing to do
-		if persistenceStatus == statusUsingPVC && isStatefulSetAvailable(r.Client) && r.isPodRunning(true, 1) {
-			return ctrl.Result{}, nil
-		}
-		//If running degraded deployment AND AllowDegradeMode is set
-		if allowdegrade && persistenceStatus == statusDegradedEmptyDir && isStatefulSetAvailable(r.Client) && r.isPodRunning(false, 1) {
-			return ctrl.Result{}, nil
-		}
-		pvcError := setupVolume(r.Client)
-		if pvcError != nil {
-			return ctrl.Result{}, pvcError
-		}
-		r.executeDeployment(r.Client, instance, true, persistence)
-		podReady := r.isPodRunning(true, waitSecondsForPodChk)
-		if podReady {
-			//Write Status
-			err := updateCRs(r.Client, instance, statusUsingPVC,
-				custom, persistence, storageClass, storageSize, customValuesInuse)
-			if err != nil {
-				return ctrl.Result{}, err
+	if setupPod {
+		if persistence {
+			//If running PVC deployment nothing to do
+			if persistenceStatus == statusUsingPVC && isStatefulSetAvailable(r.Client) && r.isPodRunning(true, 1) {
+				return ctrl.Result{}, nil
 			}
-		}
-		//If Pod cannot be scheduled rollback to EmptyDir if AllowDegradeMode is set
-		if !podReady && allowdegrade {
-			r.Log.Info("Degrading Redisgraph deployment to use empty dir.")
-			err := deleteRedisStatefulSet(r.Client)
-			if err != nil {
-				return ctrl.Result{}, err
+			//If running degraded deployment AND AllowDegradeMode is set
+			if allowdegrade && persistenceStatus == statusDegradedEmptyDir && isStatefulSetAvailable(r.Client) && r.isPodRunning(false, 1) {
+				return ctrl.Result{}, nil
 			}
-			err = deletePVC(r.Client)
-			if err != nil {
-				return ctrl.Result{}, err
+			pvcError := setupVolume(r.Client)
+			if pvcError != nil {
+				return ctrl.Result{}, pvcError
 			}
-			r.executeDeployment(r.Client, instance, false, persistence)
-			if r.isPodRunning(false, waitSecondsForPodChk) {
+			r.executeDeployment(r.Client, instance, true, persistence)
+			podReady := r.isPodRunning(true, waitSecondsForPodChk)
+			if podReady {
 				//Write Status
-				err := updateCRs(r.Client, instance, statusDegradedEmptyDir,
-					custom, false, "", "", customValuesInuse)
+				err := updateCRs(r.Client, instance, statusUsingPVC,
+					custom, persistence, storageClass, storageSize, customValuesInuse)
 				if err != nil {
 					return ctrl.Result{}, err
+				}
+			}
+			//If Pod cannot be scheduled rollback to EmptyDir if AllowDegradeMode is set
+			if !podReady && allowdegrade {
+				r.Log.Info("Degrading Redisgraph deployment to use empty dir.")
+				err := deleteRedisStatefulSet(r.Client)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				err = deletePVC(r.Client)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				r.executeDeployment(r.Client, instance, false, persistence)
+				if r.isPodRunning(false, waitSecondsForPodChk) {
+					//Write Status
+					err := updateCRs(r.Client, instance, statusDegradedEmptyDir,
+						custom, false, "", "", customValuesInuse)
+					if err != nil {
+						return ctrl.Result{}, err
+					} else {
+						return ctrl.Result{}, nil
+					}
 				} else {
-					return ctrl.Result{}, nil
+					r.Log.Info("Unable to create Redisgraph Deployment in Degraded Mode")
+					//Write Status, delete statefulset and requeue
+					r.reconcileOnError(instance, statusFailedDegraded, custom, false, "", "", customValuesInuse)
+					return ctrl.Result{RequeueAfter: 5 * time.Second}, fmt.Errorf(redisNotRunning)
+				}
+			}
+			if !podReady && !allowdegrade {
+				r.Log.Info("Unable to create Redisgraph Deployment using PVC ")
+				//Write Status, delete statefulset and requeue
+				r.reconcileOnError(instance, statusFailedUsingPVC, custom, false, "", "", customValuesInuse)
+				return ctrl.Result{RequeueAfter: 5 * time.Second}, fmt.Errorf(redisNotRunning)
+			}
+		} else {
+			if isStatefulSetAvailable(r.Client) && r.isPodRunning(false, 1) &&
+				persistenceStatus == statusNoPersistence {
+				return ctrl.Result{}, nil
+			}
+			r.Log.Info("Using Deployment with persistence disabled")
+			r.executeDeployment(r.Client, instance, false, persistence)
+			if r.isPodRunning(false, waitSecondsForPodChk) {
+				//Write Status, if error - requeue
+				err := updateCRs(r.Client, instance, statusNoPersistence, custom, false, "", "", customValuesInuse)
+				if err != nil {
+					return ctrl.Result{}, err
 				}
 			} else {
-				r.Log.Info("Unable to create Redisgraph Deployment in Degraded Mode")
+				r.Log.Info("Unable to create Redisgraph Deployment with persistence disabled")
 				//Write Status, delete statefulset and requeue
-				r.reconcileOnError(instance, statusFailedDegraded, custom, false, "", "", customValuesInuse)
+				r.reconcileOnError(instance, statusFailedNoPersistence, custom, false, "", "", customValuesInuse)
 				return ctrl.Result{RequeueAfter: 5 * time.Second}, fmt.Errorf(redisNotRunning)
 			}
 		}
-		if !podReady && !allowdegrade {
-			r.Log.Info("Unable to create Redisgraph Deployment using PVC ")
-			//Write Status, delete statefulset and requeue
-			r.reconcileOnError(instance, statusFailedUsingPVC, custom, false, "", "", customValuesInuse)
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, fmt.Errorf(redisNotRunning)
-		}
-	} else {
-		if isStatefulSetAvailable(r.Client) && r.isPodRunning(false, 1) &&
-			persistenceStatus == statusNoPersistence {
-			return ctrl.Result{}, nil
-		}
-		r.Log.Info("Using Deployment with persistence disabled")
-		r.executeDeployment(r.Client, instance, false, persistence)
-		if r.isPodRunning(false, waitSecondsForPodChk) {
-			//Write Status, if error - requeue
-			err := updateCRs(r.Client, instance, statusNoPersistence, custom, false, "", "", customValuesInuse)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
-		} else {
-			r.Log.Info("Unable to create Redisgraph Deployment with persistence disabled")
-			//Write Status, delete statefulset and requeue
-			r.reconcileOnError(instance, statusFailedNoPersistence, custom, false, "", "", customValuesInuse)
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, fmt.Errorf(redisNotRunning)
-		}
-
 	}
 	return ctrl.Result{}, nil
 }

--- a/controllers/searchoperator_controller.go
+++ b/controllers/searchoperator_controller.go
@@ -68,7 +68,7 @@ var (
 	storageClass         = ""
 	storageSize          = "10Gi"
 	namespace            = os.Getenv("WATCH_NAMESPACE")
-	setupPod, _          = strconv.ParseBool(os.Getenv("UPSTREAM"))
+	setupPod, _          = strconv.ParseBool(os.Getenv("USE_EXISTING_REDISGRAPH"))
 )
 var startingSpec searchv1alpha1.SearchCustomizationSpec
 
@@ -149,7 +149,7 @@ func (r *SearchOperatorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	// Setup RedisGraph Deployment
 	r.Log.Info(fmt.Sprintf("Config in  Use Persistence/AllowDegrade %t/%t", persistence, allowdegrade))
 	if setupPod {
-		r.Log.Info("Not deploying redisgraph. Waiting for custom deployment of Redisgraph pod")
+		r.Log.Info("Not deploying redisgraph. Using custom/existing deployment of Redisgraph pod")
 		return ctrl.Result{}, nil
 	}
 	if persistence {

--- a/controllers/searchoperator_controller.go
+++ b/controllers/searchoperator_controller.go
@@ -149,7 +149,7 @@ func (r *SearchOperatorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	// Setup RedisGraph Deployment
 	r.Log.Info(fmt.Sprintf("Config in  Use Persistence/AllowDegrade %t/%t", persistence, allowdegrade))
 	if !setupPod {
-		r.Log.Info("Not deploying redisgraph. Using custom/existing deployment of Redisgraph pod")
+		r.Log.Warn("Not deploying the database. This is not an error, it's a current limitation in this environment. The search feature is not operational.  More info: https://github.com/open-cluster-management/community/issues/34")
 		return ctrl.Result{}, nil
 	}
 	if persistence {

--- a/controllers/searchoperator_controller.go
+++ b/controllers/searchoperator_controller.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"os"
 	"reflect"
+	"strconv"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -67,6 +68,7 @@ var (
 	storageClass         = ""
 	storageSize          = "10Gi"
 	namespace            = os.Getenv("WATCH_NAMESPACE")
+	setupPod, _          = strconv.ParseBool(os.Getenv("UPSTREAM"))
 )
 var startingSpec searchv1alpha1.SearchCustomizationSpec
 
@@ -146,6 +148,10 @@ func (r *SearchOperatorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 
 	// Setup RedisGraph Deployment
 	r.Log.Info(fmt.Sprintf("Config in  Use Persistence/AllowDegrade %t/%t", persistence, allowdegrade))
+	if setupPod {
+		r.Log.Info("Not deploying redisgraph. Waiting for custom deployment of Redisgraph pod")
+		return ctrl.Result{}, nil
+	}
 	if persistence {
 		//If running PVC deployment nothing to do
 		if persistenceStatus == statusUsingPVC && isStatefulSetAvailable(r.Client) && r.isPodRunning(true, 1) {


### PR DESCRIPTION
Stop deploying redisgraph in upstream to comply with legal requirements around open sourcing. The DEPLOY_REDISGRAPH flag can be set to control the deployment.

This can only be merged after the search-api and ui changes to gracefully handle the error are ready.

For https://github.com/open-cluster-management/backlog/issues/10931