### PR TITLE
Restart search-api pods

### DIFF
--- a/controllers/searchoperator_controller.go
+++ b/controllers/searchoperator_controller.go
@@ -187,7 +187,7 @@ func (r *SearchOperatorReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 			//If Redisgraph was disabled, collector will be in a 10 minute timeout loop.
 			//Restart collector and api pods while deploying Redisgraph.
 			if err == nil && srchOp.Status.DeployRedisgraph != nil && *srchOp.Status.DeployRedisgraph == false {
-				r.Log.Info("Restarting search-collector pod")
+				r.Log.Info("Restarting search-collector and search-api pods")
 				//restart collector and api pods
 				r.restartSearchComponents()
 			}

--- a/controllers/searchoperator_controller.go
+++ b/controllers/searchoperator_controller.go
@@ -277,17 +277,6 @@ func (r *SearchOperatorReconciler) reconcileOnError(instance *searchv1alpha1.Sea
 	}
 }
 
-func getOptions(opts map[string]string) []client.ListOption {
-	listOptions := []client.ListOption{}
-	listOption := client.ListOptions{
-		LabelSelector: labels.SelectorFromSet(opts),
-		Namespace:     namespace,
-		Limit:         2, //setting this to 2 as a safety net while deleting pods
-	}
-	listOptions = append(listOptions, &listOption)
-	return listOptions
-}
-
 // Restart search collector and api pods
 func (r *SearchOperatorReconciler) restartSearchComponents() {
 	allComponents := map[string]map[string]string{}
@@ -895,4 +884,15 @@ func (r *SearchOperatorReconciler) setupSecret(client client.Client, cr *searchv
 		log.Info("Skip reconcile: Secret already exists", "Secret.Namespace", found.Namespace, "Secret.Name", found.Name)
 	}
 	return nil
+}
+
+func getOptions(opts map[string]string) []client.ListOption {
+	listOptions := []client.ListOption{}
+	listOption := client.ListOptions{
+		LabelSelector: labels.SelectorFromSet(opts),
+		Namespace:     namespace,
+		Limit:         2, //setting this to 2 as a safety net while deleting pods
+	}
+	listOptions = append(listOptions, &listOption)
+	return listOptions
 }

--- a/controllers/searchoperator_controller.go
+++ b/controllers/searchoperator_controller.go
@@ -296,13 +296,13 @@ func (r *SearchOperatorReconciler) restartSearchComponents() {
 		}
 
 		for _, item := range podList.Items {
-			collectorPod := &v1.Pod{
+			compPod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      item.Name,
 					Namespace: item.Namespace,
 				},
 			}
-			err := r.Client.Delete(context.TODO(), collectorPod)
+			err := r.Client.Delete(context.TODO(), compPod)
 			if err != nil && !errors.IsNotFound(err) {
 				r.Log.Info("Failed to delete pods for ", "component", compName)
 				r.Log.Info(err.Error())

--- a/controllers/searchoperator_controller_test.go
+++ b/controllers/searchoperator_controller_test.go
@@ -417,7 +417,7 @@ func TestRestartCollector(t *testing.T) {
 	client := fake.NewFakeClientWithScheme(testSetup.scheme, testSetup.srchOperator, collectorPod)
 	nilSearchOperator := SearchOperatorReconciler{client, log, testSetup.scheme}
 
-	nilSearchOperator.restartCollector()
+	nilSearchOperator.restartSearchComponents()
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: namespace,


### PR DESCRIPTION
To restart search-api pods after re-enabling rediagraph. To recover from the bug where search-api doesn't connect to Redis (spotted during internal-demo).
For https://github.com/open-cluster-management/backlog/issues/11303