### PR TITLE
[release-2.2] Set user 1001 (non root) in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,5 @@ ENV OPERATOR=/usr/local/bin/search-operator \
     USER_UID=1001 \
     USER_NAME=search-operator
 
+USER ${USER_UID}
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Issue: https://bugzilla.redhat.com/show_bug.cgi?id=1967953

Same as PR for main branch. https://github.com/open-cluster-management/search-operator/pull/62